### PR TITLE
Add Network Unavailable banner

### DIFF
--- a/src/assets/jss/components/Header/headerStyle.tsx
+++ b/src/assets/jss/components/Header/headerStyle.tsx
@@ -75,6 +75,19 @@ const adStyle = (theme: Theme) =>
     invisible: {
       opacity: 0,
     },
+    networkUnavailableBanner: {
+      background: 'linear-gradient(90deg, #f6a143, #ffcd85)',
+      color: 'black',
+      display: 'flex',
+      height: '48px',
+      alignItems: 'center',
+      justifyContent: 'center',
+      margin: theme.spacing(0, -10),
+      [theme.breakpoints.down('sm')]: {
+        marginTop: theme.spacing(-2),
+        marginBottom: theme.spacing(1),
+      },
+    },
   })
 
 export default adStyle

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -108,7 +108,7 @@ const Footer = () => {
             <a href='https://twitter.com/ironfishcrypto'>
               <img src={twitter} alt={t('app.footer.twitter')} />
             </a>
-            <a href='https://discord.gg/H7Mk3qacyM'>
+            <a href='https://discord.gg/kpKeGkA3'>
               <img src={discord} alt={t('app.footer.discord')} />
             </a>
           </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,6 +15,10 @@ import Search from '../../container/Search/Search'
 
 const useStyles = makeStyles(headerStyle)
 
+// Config value for showing the "Network Unavailable" banner.
+// Set this to 'false' if the network is not available.
+const isNetworkAvailable = true
+
 interface Props {
   showSearch: Boolean
   isSticky?: Boolean
@@ -32,6 +36,22 @@ const Header = ({ isSticky, isTop, showSearch }: Props) => {
         [classes.isTop]: showSearch && isTop,
       })}
     >
+      {!isNetworkAvailable && (
+        <div className={classes.networkUnavailableBanner}>
+          <span>
+            <strong>Network Unavailable.</strong> Check{' '}
+            <a
+              href='https://discord.gg/H7Mk3qacyM'
+              target='_blank'
+              rel='noreferrer'
+              style={{ color: 'black' }}
+            >
+              Discord
+            </a>{' '}
+            for updates.
+          </span>
+        </div>
+      )}
       <Toolbar className={classes.toolbar}>
         <Link to={RoutePath.Home}>
           <img

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,7 +41,7 @@ const Header = ({ isSticky, isTop, showSearch }: Props) => {
           <span>
             <strong>Network Unavailable.</strong> Check{' '}
             <a
-              href='https://discord.gg/H7Mk3qacyM'
+              href='https://discord.gg/kpKeGkA3'
               target='_blank'
               rel='noreferrer'
               style={{ color: 'black' }}


### PR DESCRIPTION
Adds a banner we can manually deploy to flip on if the network is no longer available.
