### PR TITLE
Update Discord link to one with unlimited duration

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -108,7 +108,7 @@ const Footer = () => {
             <a href='https://twitter.com/ironfishcrypto'>
               <img src={twitter} alt={t('app.footer.twitter')} />
             </a>
-            <a href='https://discord.gg/kpKeGkA3'>
+            <a href='https://discord.gg/EkQkEcm8DH'>
               <img src={discord} alt={t('app.footer.discord')} />
             </a>
           </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,7 +41,7 @@ const Header = ({ isSticky, isTop, showSearch }: Props) => {
           <span>
             <strong>Network Unavailable.</strong> Check{' '}
             <a
-              href='https://discord.gg/kpKeGkA3'
+              href='https://discord.gg/EkQkEcm8DH'
               target='_blank'
               rel='noreferrer'
               style={{ color: 'black' }}


### PR DESCRIPTION
The Discord link was set to expire after a week and pointing at the wrong channel. Updated to one that points at #announcements.

Fixes IRO-632
