### PR TITLE
IRO-1400: Allow sequence in the URL for block explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 Block Explorer for Iron Fish blockchain
 
 ## Dev setup
-Run the Iron Fish Rosetta API
-`cd ironfish/ironfish-rosetta-api`
-`yarn start`
-The Rosetta API is set to run on `localhost:8080`. If the port is different on your machine, update the `package.json` for CORS
+To test block-explorer locally you have to run the Iron Fish API and Iron Fish node locally
+`cd iron-fish/ironfish-api`
+follow the config and run instruction.
+`nps start`
+The Iron Fish API is set to run on `localhost:8003`. If the port is different on your machine, update the `package.json` for CORS
 
 Run a Full node
 `cd ironfish/ironfish-cli`
-`yarn start start`
+`yarn start:once start`
+`yarn start:once service:sync`
 
 Run the block explorer
 `yarn dev`

--- a/src/container/BlockDetailPage/BlockDetailPage.tsx
+++ b/src/container/BlockDetailPage/BlockDetailPage.tsx
@@ -29,18 +29,21 @@ const BlockDetailPage = () => {
   const { id } = useParams<ParamTypes>()
 
   const blockIdentifier = {} as { hash?: string; sequence?: number }
+  const queryParams: any = {}
+
   if (Number.isNaN(Number(id))) {
     blockIdentifier.hash = id
+    queryParams.hash = id
+    queryParams.with_transactions = true
   } else {
     blockIdentifier.sequence = Number(id)
+    queryParams.sequence = Number(id)
+    queryParams.with_transactions = true
   }
 
   const service = useGetService<Block>(
     getApiUrl(ApiUrls.BLOCK_DETAIL_PAGE),
-    {
-      hash: id,
-      with_transactions: true,
-    },
+    queryParams,
     (block) => formatBlockFromJson({ block }),
   )
 


### PR DESCRIPTION
Tested locally:
request by block sequence:
![image](https://user-images.githubusercontent.com/90644789/145931745-df8c09b8-87fd-40c9-b91e-043b00bb48cc.png)

request by block hash
![image](https://user-images.githubusercontent.com/90644789/145931716-e1dc92e2-20ef-4d47-a5d4-fa7f7ec86e8b.png)

