### PR TITLE
Fixed difficulty y-axis labels not fitting

### DIFF
--- a/src/components/Charts/Difficulty.tsx
+++ b/src/components/Charts/Difficulty.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 export default function Difficulty({ data }: Props): JSX.Element {
-  const yAccessor = React.useCallback((d: Metric) => d.average_difficulty, [])
+  const yAccessor = React.useCallback((d: Metric) => Math.round(d.average_difficulty / 1e9), [])
 
   return <GeneralChart data={data} marginLeft={90} yAccessor={yAccessor} />
 }

--- a/src/container/ChartsPage/ChartsPage.tsx
+++ b/src/container/ChartsPage/ChartsPage.tsx
@@ -97,7 +97,7 @@ const ChartsPage = () => {
               <UniqueGraffiti data={metricsData} />
             </ChartBox>
 
-            <ChartBox header='Difficulty'>
+            <ChartBox header='Difficulty (x10^9)'>
               <Difficulty data={metricsData} />
             </ChartBox>
 


### PR DESCRIPTION
## Summary

For https://explorer.ironfish.network/charts:
Made chart show difficulty in billions

## Testing Plan

Visual check of /charts (on prod should be https://explorer.ironfish.network/charts)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ x] No
```
