### PR TITLE
Fix linking to blocks by hash

### DIFF
--- a/hooks/useBlock.tsx
+++ b/hooks/useBlock.tsx
@@ -1,0 +1,24 @@
+import { useContext, useEffect } from 'react'
+
+import { BlockContext } from 'contexts/ServiceContexts'
+import { BlockType } from 'types'
+import useAsyncDataWrapper from './useAsyncDataWrapper'
+
+const useBlock = (id: string) => {
+  const service = useContext(BlockContext)
+  const [result, wrapper] = useAsyncDataWrapper<BlockType>()
+
+  useEffect(() => {
+    if (id) {
+      const options = isNaN(Number(id))
+        ? { hash: id, with_transactions: true }
+        : { sequence: Number(id), with_transactions: true }
+
+      wrapper(service.find(options))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
+  return result
+}
+
+export default useBlock

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -7,7 +7,6 @@ import pipe from 'ramda/src/pipe'
 
 import { CardContainer, Card, TimeStamp } from 'components'
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs'
-import useBlockBySeq from 'hooks/useBlockBySeq'
 import {
   DifficultyIcon,
   BlockInfoHeightIcon,
@@ -22,6 +21,7 @@ import safeProp from 'utils/safeProp'
 import { TransactionsTable } from 'components/TransactionsTable'
 import { BlockType } from 'types'
 import { CopyValueToClipboard } from 'components'
+import useBlock from 'hooks/useBlock'
 
 const BLOCK_CARDS = [
   {
@@ -76,7 +76,7 @@ const BLOCK_CARDS = [
 ]
 
 const BlockInfo = ({ id }) => {
-  const block = useBlockBySeq(id)
+  const block = useBlock(id)
 
   return (
     <>


### PR DESCRIPTION
This will allow you to link by hash, which fixes links in the node, and other places.

I duplicated the hook in https://github.com/iron-fish/block-explorer-v2/blob/master/hooks/useBlockBySeq.tsx to figure out if the id is a hash or sequence.