### PR TITLE
Fix navigation on transaction/block page when 404 page is shown

### DIFF
--- a/hooks/useBlock.tsx
+++ b/hooks/useBlock.tsx
@@ -7,18 +7,23 @@ import useAsyncDataWrapper from './useAsyncDataWrapper'
 const useBlock = (id: string) => {
   const service = useContext(BlockContext)
   const [result, wrapper] = useAsyncDataWrapper<BlockType>()
+  const wrappedServiceCall = () => {
+    const options = isNaN(Number(id))
+      ? { hash: id, with_transactions: true }
+      : { sequence: Number(id), with_transactions: true }
+    return wrapper(service.find(options))
+  }
 
   useEffect(() => {
     if (id) {
-      const options = isNaN(Number(id))
-        ? { hash: id, with_transactions: true }
-        : { sequence: Number(id), with_transactions: true }
-
-      wrapper(service.find(options))
+      wrappedServiceCall()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id])
-  return result
+  return {
+    ...result,
+    refresh: () => wrappedServiceCall(),
+  }
 }
 
 export default useBlock

--- a/hooks/useTransactionByHash.tsx
+++ b/hooks/useTransactionByHash.tsx
@@ -1,18 +1,23 @@
-import { useContext, useEffect } from "react"
+import { useContext, useEffect } from 'react'
 
-import { TransactionContext } from "contexts/ServiceContexts"
-import { TransactionType } from "types"
-import useAsyncDataWrapper from "./useAsyncDataWrapper"
+import { TransactionContext } from 'contexts/ServiceContexts'
+import { TransactionType } from 'types'
+import useAsyncDataWrapper from './useAsyncDataWrapper'
 
 const useTransactionByHash = (hash: string) => {
   const service = useContext(TransactionContext)
   const [result, wrapper] = useAsyncDataWrapper<TransactionType>()
+  const wrappedServiceCall = () =>
+    wrapper(service.find({ hash, with_blocks: true }))
 
   useEffect(() => {
-    hash && wrapper(service.find({ hash, with_blocks: true }))
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    hash && wrappedServiceCall()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hash])
-  return result
+  return {
+    ...result,
+    refresh: () => wrappedServiceCall(),
+  }
 }
 
 export default useTransactionByHash

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -22,6 +22,7 @@ import { TransactionsTable } from 'components/TransactionsTable'
 import { BlockType } from 'types'
 import { CopyValueToClipboard, InfoBadge } from 'components'
 import useBlock from 'hooks/useBlock'
+import Error from 'pages/_error'
 
 const BLOCK_CARDS = [
   {
@@ -75,18 +76,12 @@ const BLOCK_CARDS = [
   },
 ]
 
-const BlockInfo = ({ id }) => {
-  const block = useBlock(id)
-
-  if (block.error) {
-    throw block.error
-  }
-
+const BlockInfo = ({ data, loaded }) => {
   return (
     <>
       <Flex mt="0.5rem" mb="2rem" align="center">
         <h3>Block Information</h3>
-        {block.data?.main === false && (
+        {data?.main === false && (
           <InfoBadge ml={'1rem'} message={'Forked Block'} />
         )}
       </Flex>
@@ -101,9 +96,9 @@ const BlockInfo = ({ id }) => {
               '2xl': 'max(20rem, 33.333333% - 1rem)',
             }}
             label={card.label}
-            value={card.value(block.data)}
+            value={card.value(data)}
             icon={card.icon}
-            isLoading={!block.loaded}
+            isLoading={!loaded}
           />
         ))}
       </CardContainer>
@@ -112,10 +107,10 @@ const BlockInfo = ({ id }) => {
       </Box>
       <TransactionsTable
         data={
-          block.loaded
-            ? block.data?.transactions.map(transaction => ({
+          loaded
+            ? data?.transactions.map(transaction => ({
                 ...transaction,
-                blocks: [block.data],
+                blocks: [data],
               }))
             : [null]
         }
@@ -124,20 +119,34 @@ const BlockInfo = ({ id }) => {
   )
 }
 
+const BlockNotFound = ({ refresh }) => (
+  <>
+    <Head>
+      <title>Iron Fish: Block not found</title>
+    </Head>
+    <Error handleReload={refresh} error />
+  </>
+)
+
 export default function BlockInformationPage() {
   const router = useRouter()
   const { id } = router.query
+  const { error, loaded, data, refresh } = useBlock(id as string)
+
+  if (error) {
+    return <BlockNotFound refresh={refresh} />
+  }
 
   return (
     <main style={{ width: '100%', height: '100%' }}>
       <Head>
-        <title>Iron Fish: Block {id}</title>
+        <title>Iron Fish: Block {data?.id}</title>
       </Head>
       <Box mx={{ base: '2rem', lg: '15%' }} mb="6rem" zIndex={1}>
         <Box mt="2.5rem">
           <Breadcrumbs />
         </Box>
-        <BlockInfo id={id} />
+        <BlockInfo data={data} loaded={loaded} />
       </Box>
     </main>
   )

--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -15,6 +15,7 @@ import { useRouter } from 'next/router'
 import size from 'byte-size'
 import pathOr from 'ramda/src/pathOr'
 import pipe from 'ramda/src/pipe'
+import Error from 'pages/_error'
 
 import { Card, CardContainer, CopyValueToClipboard } from 'components'
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs'
@@ -243,15 +244,24 @@ const TransactionInfo = ({ data, loaded }) => {
   )
 }
 
+const TransactionNotFound = ({ refresh }) => (
+  <>
+    <Head>
+      <title>Iron Fish: Transaction not found</title>
+    </Head>
+    <Error handleReload={refresh} error />
+  </>
+)
+
 export default function TransactionInformationPage() {
   const router = useRouter()
   const { hash } = router.query
 
-  const { data, loaded, error } = useTransactionByHash(hash as string)
+  const { data, loaded, error, refresh } = useTransactionByHash(hash as string)
   const block = pathOr({}, ['blocks', 0])(data)
 
   if (error) {
-    throw error
+    return <TransactionNotFound refresh={refresh} />
   }
 
   return (


### PR DESCRIPTION
When a transaction or block is not found via API, an error is thrown and it was caught inside ErrorBoundary.
After that, when the user search for another existing txn or block, the page was not refreshing, displaying the same 404 layout.

Fixed by removing the error throw, displaying layout directly from `pages/_error`. Added refresh call to service.
Also, set the proper page title.