### PR TITLE
Change navbar logo to redirect to ironfish.network

### DIFF
--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -139,7 +139,7 @@ const Navbar: FC = () => {
         borderColor={$colors.border}
         justifyContent="space-between"
       >
-        <Link href={RoutePaths.Home} passHref>
+        <Link href={RoutePaths.IronfishNetwork} passHref>
           <Box
             order={1}
             justifySelf="flex-start"

--- a/constants/RoutePaths.ts
+++ b/constants/RoutePaths.ts
@@ -5,6 +5,7 @@ enum RoutePaths {
   TransactionInfo = '/transaction/[hash]',
   BlockInfo = '/blocks/[id]',
   Charts = '/charts',
+  IronfishNetwork = 'https://ironfish.network/'
 }
 
 export default RoutePaths


### PR DESCRIPTION
Clicking on the Nav bar ironfish logo should redirect us to the ironfish website. This PR fixes that. This would be consistent with the ironfish logo found everywhere else