### PR TITLE
Display timestamps in transaction and block pages in UTC timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@react-three/fiber": "^8.0.19",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.6",
     "konva": "^8.3.8",
     "next": "^12.1.6",
     "ramda": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@react-three/fiber": "^8.0.19",
     "date-fns": "^2.28.0",
-    "date-fns-tz": "^1.3.6",
+    "date-fns-tz": "1.3.6",
     "konva": "^8.3.8",
     "next": "^12.1.6",
     "ramda": "^0.28.0",

--- a/utils/format/timestamp.ts
+++ b/utils/format/timestamp.ts
@@ -4,8 +4,8 @@ import pipe from 'ramda/src/pipe'
 import K from 'ramda/src/always'
 import ifElse from 'ramda/src/ifElse'
 import isNil from 'ramda/src/isNil'
-import { parseISO, formatWithOptions } from 'date-fns/fp'
-import { enUS } from 'date-fns/locale'
+import { parseISO } from 'date-fns/fp'
+import { formatInTimeZone } from 'date-fns-tz/fp'
 
 export const formatBlockTimestamp = ifElse(
   propOr(false, 'timestamp'),
@@ -13,7 +13,7 @@ export const formatBlockTimestamp = ifElse(
     prop('timestamp'),
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatWithOptions({ locale: enUS }, `dd'/'MM'/'yyyy hh':'mm':'ss aa`)
+    formatInTimeZone(`dd'-'MM'-'yyyy kk':'mm':'ss`, 'UTC')
   ),
   K('')
 )
@@ -24,7 +24,7 @@ export const formatDate = ifElse(
   pipe(
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatWithOptions({ locale: enUS }, `dd'/'MM'/'yyyy`)
+    formatInTimeZone(`dd'-'MM'-'yyyy`, 'UTC')
   )
 )
 
@@ -34,6 +34,6 @@ export const formatTime = ifElse(
   pipe(
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatWithOptions({ locale: enUS }, `hh':'mm':'ss aa`)
+    formatInTimeZone(`kk':'mm':'ss`, 'UTC')
   )
 )

--- a/utils/format/timestamp.ts
+++ b/utils/format/timestamp.ts
@@ -13,7 +13,7 @@ export const formatBlockTimestamp = ifElse(
     prop('timestamp'),
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatInTimeZone(`dd'-'MM'-'yyyy kk':'mm':'ss`, 'UTC')
+    formatInTimeZone(`dd'-'MM'-'yyyy kk':'mm':'ss zzz`, 'UTC')
   ),
   K('')
 )
@@ -34,6 +34,6 @@ export const formatTime = ifElse(
   pipe(
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatInTimeZone(`kk':'mm':'ss`, 'UTC')
+    formatInTimeZone(`kk':'mm':'ss zzz`, 'UTC')
   )
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,7 +3753,7 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-date-fns-tz@^1.3.6:
+date-fns-tz@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
   integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,6 +3753,11 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+date-fns-tz@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
+  integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
+
 date-fns@^1.23.0:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
Display timestamps in the same format as on the leaderboard, in UTC timezone.

Txn example `443a00f8279c293bc9c6b19fd7e430f0da11366214bd654f4f4842f188748a2e`

<img width="792" alt="Screen Shot 2022-08-24 at 11 49 28" src="https://user-images.githubusercontent.com/1768919/186374414-c7bf9489-4892-4b97-82a7-94d1f92e63c8.png">
<img width="966" alt="Screen Shot 2022-08-24 at 11 49 17" src="https://user-images.githubusercontent.com/1768919/186374426-29f402ba-11d3-4710-a765-723c455141ee.png">

