### PR TITLE
Fix: use blockHash of onChain block

### DIFF
--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -153,7 +153,12 @@ const TRANSACTION_INFO_CARDS = [
     key: 'block-hash-card',
     label: 'Block Hash',
     value: (transaction: TransactionType | null) => {
-      const hash = pathOr('', ['blocks', 0, 'hash'])(transaction)
+      const index = transaction?.blocks.findIndex(block => block.main === true)
+      const hash = pathOr('', [
+        'blocks',
+        index === undefined || index === -1 ? 0 : index,
+        'hash',
+      ])(transaction)
       return <CopyValueToClipboard value={hash} label={truncateHash(hash, 2)} />
     },
     icon: <DifficultyIcon />,


### PR DESCRIPTION
Use blockHash of onChain block for transaction if we can, instead of the first one in transaction.blocks.