### PR TITLE
Label of transactions_count-card

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,7 +47,7 @@ const LAST_BLOCK_INFO_CARDS = [
   },
   {
     key: 'transactions_count-card',
-    label: 'Blocks in last transaction',
+    label: 'Transactions in last block',
     value: (block: BlockType | null) => block?.transactions_count,
     icon: <BlockInfoTxnIcon />,
   },


### PR DESCRIPTION
To change the label of the transactions_count-card from "Blocks in last transaction" to "Transactions in last block".