### PR TITLE
Don't render node version when error is returned from API

### DIFF
--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -44,9 +44,9 @@ const NodeVersionButton: FC<StyleProps> = (props: StyleProps) => {
   const versionUrl = useMemo(
     () =>
       `https://github.com/iron-fish/ironfish/releases/${
-        loaded ? 'tag/v' + data.ironfish.version : ''
+        loaded && !error ? 'tag/v' + data.ironfish.version : ''
       }`,
-    [loaded, data]
+    [loaded, data, error]
   )
 
   if (error) {

--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -43,12 +43,11 @@ const NodeVersionButton: FC<StyleProps> = (props: StyleProps) => {
 
   const versionUrl = useMemo(
     () =>
-      `https://github.com/iron-fish/ironfish/releases/${
-        loaded && !error && data?.ironfish
-          ? 'tag/v' + data.ironfish.version
-          : ''
-      }`,
-    [loaded, data, error]
+      'https://github.com/iron-fish/ironfish/releases' +
+      (loaded && !error && data.ironfish
+        ? '/tag/v' + data.ironfish.version
+        : ''),
+    [loaded, error, data]
   )
 
   // If an error or API returns an empty version list

--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -44,12 +44,15 @@ const NodeVersionButton: FC<StyleProps> = (props: StyleProps) => {
   const versionUrl = useMemo(
     () =>
       `https://github.com/iron-fish/ironfish/releases/${
-        loaded && !error ? 'tag/v' + data.ironfish.version : ''
+        loaded && !error && data?.ironfish
+          ? 'tag/v' + data.ironfish.version
+          : ''
       }`,
     [loaded, data, error]
   )
 
-  if (error) {
+  // If an error or API returns an empty version list
+  if (error || !data?.ironfish) {
     return null
   }
 

--- a/types/domain/NodeVersionType.ts
+++ b/types/domain/NodeVersionType.ts
@@ -1,5 +1,5 @@
 export interface NodeVersionType {
-  ironfish: {
+  ironfish?: {
     object: string
     version: string
     created_at: string


### PR DESCRIPTION
Was failing to render when I was running my API locally (and there was no version in the database). I think the site should still load in this situation, just don't show the link to the latest version