### PR TITLE
Set proper hour format

### DIFF
--- a/utils/format/timestamp.ts
+++ b/utils/format/timestamp.ts
@@ -13,7 +13,7 @@ export const formatBlockTimestamp = ifElse(
     prop('timestamp'),
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatInTimeZone(`dd'-'MM'-'yyyy kk':'mm':'ss zzz`, 'UTC')
+    formatInTimeZone(`dd'-'MM'-'yyyy HH':'mm':'ss zzz`, 'UTC')
   ),
   K('')
 )
@@ -34,6 +34,6 @@ export const formatTime = ifElse(
   pipe(
     parseISO,
     // TODO: figure out a way to deal with this when we do i18n
-    formatInTimeZone(`kk':'mm':'ss zzz`, 'UTC')
+    formatInTimeZone(`HH':'mm':'ss zzz`, 'UTC')
   )
 )


### PR DESCRIPTION
According to docs, https://date-fns.org/v2.29.3/docs/format, 
`kk` displays 01-24 hour format (eg. 24:12:30), 
`HH` is for 00-23 (eg 00:12:30)
 
