### PR TITLE
Display 2 decimal places for block and transaction sizes

### DIFF
--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -53,7 +53,7 @@ const BLOCK_CARDS = [
   {
     key: 'size-card',
     label: 'Size',
-    value: pipe(safeProp('size'), size, z => z.toString()),
+    value: pipe(safeProp('size'), x => size(x, { precision: 2 }).toString()),
     icon: <BlockInfoSizeIcon />,
   },
   {

--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -189,7 +189,7 @@ const TRANSACTION_INFO_CARDS = [
   {
     key: 'size-card',
     label: 'Size',
-    value: pipe(safeProp('size'), size, z => z.toString()),
+    value: pipe(safeProp('size'), x => size(x, { precision: 2 }).toString()),
     icon: <SizeIcon />,
   },
   {


### PR DESCRIPTION
Matches the precision displayed on other block explorers