### PR TITLE
Display 2 decimal places for transaction and block sizes

### DIFF
--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -53,7 +53,7 @@ const BLOCK_CARDS = [
   {
     key: 'size-card',
     label: 'Size',
-    value: pipe(safeProp('size'), size, z => z.toString()),
+    value: pipe(safeProp('size'), x => size(x, { precision: 2 }).toString()),
     icon: <BlockInfoSizeIcon />,
   },
   {

--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -189,7 +189,7 @@ const TRANSACTION_INFO_CARDS = [
   {
     key: 'size-card',
     label: 'Size',
-    value: pipe(safeProp('size'), size, z => z.toString()),
+    value: pipe(safeProp('size'), x => size(x, { precision: 2 }).toString()),
     icon: <SizeIcon />,
   },
   {


### PR DESCRIPTION
This matches the size precision displayed on most of the other block explorers.