### PR TITLE
Fix breadcrumb overflow in mobile view.

### DIFF
--- a/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/components/Breadcrumbs/Breadcrumbs.tsx
@@ -133,6 +133,9 @@ const Breadcrumbs: FC<BreadCrumbProps> = ({ queryParams }) => {
       spacing="1rem"
       pt="1rem"
       pb="1.5rem"
+      listProps={{
+        flexWrap: 'wrap',
+      }}
     >
       {resolvePath(route, queryParams).map(breadcrumb => (
         <BreadcrumbItem key={breadcrumb.key}>{breadcrumb.link}</BreadcrumbItem>


### PR DESCRIPTION
[IFL-296](https://linear.app/if-labs/issue/IFL-296/fix-breadcrumb-in-mobile-view-in-block-explorer)