### PR TITLE
fix: Buggy infinite loading on /blocks page

### DIFF
--- a/components/BlocksTable/BlocksTable.tsx
+++ b/components/BlocksTable/BlocksTable.tsx
@@ -48,9 +48,6 @@ const COLUMNS: ColumnProps<BlockType>[] = [
   {
     key: 'block-graffiti',
     label: 'Graffiti',
-    WrapperProps: {
-      display: { base: 'flex', lg: 'block' },
-    },
     ItemProps: {
       flex: { base: 1, lg: 'unset' },
     },

--- a/hooks/useInfiniteBlocks.tsx
+++ b/hooks/useInfiniteBlocks.tsx
@@ -68,10 +68,7 @@ const useInfiniteBlocks = (
       error,
       data: {
         ...blocksData,
-        metadata: {
-          has_next: blocksData.data[blocksData.data.length - 1]?.id > 0,
-          has_previous: true,
-        },
+        metadata: blocksData.metadata,
       },
     },
     loadNext,

--- a/pages/blocks/index.tsx
+++ b/pages/blocks/index.tsx
@@ -22,9 +22,6 @@ const InfiniteBlocks = ({ reload, onReloaded }) => {
     reloadBlocks,
   ] = useInfiniteBlocks(BLOCK_CHUNK_SIZE)
 
-  // eslint-disable-next-line
-  console.log({ data, metadata })
-
   const [observerRef] = useInfiniteScroll({
     loading: !loaded,
     hasNextPage: metadata?.has_next,

--- a/pages/blocks/index.tsx
+++ b/pages/blocks/index.tsx
@@ -21,6 +21,9 @@ const InfiniteBlocks = ({ reload, onReloaded }) => {
     loadNext,
     reloadBlocks,
   ] = useInfiniteBlocks(BLOCK_CHUNK_SIZE)
+
+  console.log({ data, metadata })
+
   const [observerRef] = useInfiniteScroll({
     loading: !loaded,
     hasNextPage: metadata?.has_next,

--- a/pages/blocks/index.tsx
+++ b/pages/blocks/index.tsx
@@ -22,6 +22,7 @@ const InfiniteBlocks = ({ reload, onReloaded }) => {
     reloadBlocks,
   ] = useInfiniteBlocks(BLOCK_CHUNK_SIZE)
 
+  // eslint-disable-next-line
   console.log({ data, metadata })
 
   const [observerRef] = useInfiniteScroll({


### PR DESCRIPTION
Fixes issue on all blocks page that was causing the infinite loader to trigger even if there were no more pages.

Does this by passing the has_next and has_previous values directly from the API, rather than trying to decipher that on the front-end.