### PR TITLE
Fix stats display

### DIFF
--- a/components/Charts/Difficulty.tsx
+++ b/components/Charts/Difficulty.tsx
@@ -6,17 +6,17 @@ import Metric from 'types/domain/Metric'
 import { getAverageWithAccessor } from 'utils/getAverageWithAccessor'
 
 const Difficulty: FC<Pick<GeneralChartProps, 'data'>> = ({ data }) => {
-  const valueAccessor = (d: Metric) => d.average_difficulty / 1e12
+  const valueAccessor = (d: Metric) => d.average_difficulty / 1e15
 
   return (
     <ChartBox
-      header="Difficulty (in trillions)"
+      header="Difficulty (in quadrillion)"
       average={getAverageWithAccessor(valueAccessor)(data)}
     >
       <GeneralChart
         yAccessor={valueAccessor}
         data={data}
-        leftAxisFormatter={d => `${d}T`}
+        leftAxisFormatter={d => `${d}P`}
       />
     </ChartBox>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,8 @@ const LAST_BLOCK_INFO_CARDS = [
   {
     key: 'difficulty-card',
     label: 'Difficulty',
-    value: (block: BlockType | null) => block?.difficulty,
+    value: (block: BlockType | null) =>
+      `${(Number(block?.difficulty) / 1e15).toFixed(2)}P`,
     icon: <DifficultyIcon />,
   },
   {
@@ -54,7 +55,7 @@ const LAST_BLOCK_INFO_CARDS = [
     key: 'interval-card',
     label: 'Last Block Time',
     value: (block: BlockType | null) =>
-      Math.floor(block?.time_since_last_block_ms / 1000),
+      `${Math.floor(block?.time_since_last_block_ms / 1000)}s`,
     icon: <SecondsToBlockIcon />,
   },
   {


### PR DESCRIPTION
1 - Show difficulty values as quadrillion on charts and main page to fix https://github.com/iron-fish/block-explorer/issues/148.
2 - Show `s` in `Last Block Time` on main page