### PR TITLE
Increase left margin for the difficulty chart

### DIFF
--- a/components/Charts/Difficulty.tsx
+++ b/components/Charts/Difficulty.tsx
@@ -17,7 +17,7 @@ const Difficulty: FC<Pick<GeneralChartProps, 'data'>> = ({ data }) => {
         yAccessor={valueAccessor}
         data={data}
         leftAxisFormatter={d => `${d}T`}
-        marginLeft={10}
+        marginLeft={80}
       />
     </ChartBox>
   )

--- a/components/Charts/Difficulty.tsx
+++ b/components/Charts/Difficulty.tsx
@@ -17,6 +17,7 @@ const Difficulty: FC<Pick<GeneralChartProps, 'data'>> = ({ data }) => {
         yAccessor={valueAccessor}
         data={data}
         leftAxisFormatter={d => `${d}T`}
+        marginLeft={10}
       />
     </ChartBox>
   )


### PR DESCRIPTION
Y axis of difficulty chart is trunked off.  Increase left margin for the difficulty chart.

@rohanjadvani @dgca 