### PR TITLE
Add millisecond support to formatTimeSinceLastBlock

### DIFF
--- a/utils/format/formatTimeSinceLastBlock.ts
+++ b/utils/format/formatTimeSinceLastBlock.ts
@@ -6,6 +6,11 @@ const BASE_DATE = new Date(0)
 export const formatTimeSinceLastBlock = (miningTimeInMs?: number) => {
   if (!miningTimeInMs) return ''
 
+  if (miningTimeInMs < 1000) {
+    return `${miningTimeInMs}ms`
+  }
+
   const endDate = new Date(BASE_DATE.getTime() + miningTimeInMs)
+
   return formatDuration(intervalToDuration({ start: BASE_DATE, end: endDate }))
 }


### PR DESCRIPTION
formatTimeSinceLastBlock doesn't support times under 1 second because date-fns library doesn't in its duration support. We have to special case this, or move to a different library.

You can see a broken block here, https://explorer.ironfish.network/blocks/11513