### PR TITLE
Fix crash in page because of no key

### DIFF
--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -128,6 +128,7 @@ const BlockInfo = ({ id }) => {
             />
           ) : (
             <Box
+              key={null}
               width={{
                 base: 'max(20rem, 100% - 0.5rem)',
                 md: 'max(20rem, 50% - 1rem)',


### PR DESCRIPTION
This box element is an element in a list that doesn't have a key, which
causes an exception to be thrown. In react, you need to have a key for
elements in a list.

```bash
xt-dev.js:25 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `BlockInfo`. See https://reactjs.org/link/warning-keys for more information.
    at ChakraComponent (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.js:228:71)
    at BlockInfo (webpack-internal:///./pages/blocks/[id].tsx:178:20)
    at div
    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-cbed451f.browser.esm.js:57:66)
    at ChakraComponent (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.js:228:71)
    at main
    at BlockInformationPage (webpack-internal:///./pages/blocks/[id].tsx:299:72)
    at ErrorBoundary (webpack-internal:///./components/ErrorBoundary.tsx:86:9)
    at Layout (webpack-internal:///./components/Layout/Layout.tsx:11:26)
    at ServiceContexts (webpack-internal:///./contexts/ServiceContexts.tsx:32:26)
    at EnvironmentProvider (webpack-internal:///./node_modules/@chakra-ui/react-env/dist/index.js:51:11)
    at ColorModeProvider (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.js:180:5)
    at ThemeProvider (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-cbed451f.browser.esm.js:96:64)
    at ThemeProvider (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.js:129:11)
    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/provider/dist/index.js:35:5)
    at ChakraProvider2 (webpack-internal:///./node_modules/@chakra-ui/react/dist/index.js:83:5)
    at IronFishUIProvider (webpack-internal:///./node_modules/@ironfish/ui-kit/dist/components/IronFishUIProvider.js:26:17)
    at QueryClientProvider (webpack-internal:///./node_modules/@tanstack/react-query/build/lib/QueryClientProvider.mjs:47:3)
    at MyApp (webpack-internal:///./pages/_app.tsx:53:27)
    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:20746)
    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:23395)
    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:323:9)
    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:825:26)
    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:949:27)

```