### PR TITLE
adds support for displaying pending transactions

### DIFF
--- a/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/components/Breadcrumbs/Breadcrumbs.tsx
@@ -85,33 +85,39 @@ const resolvePath = (path: string, queryParams: ParsedUrlQuery | null) => {
         },
       ]
     case RoutePaths.TransactionInfo:
-      return [
+      const breadcrumbs = [
         {
           key: 'breadcrumb-home',
           link: <BreadcrumbLink.Home />,
         },
-        {
-          key: 'breadcrumb-explorer',
-          link: <BreadcrumbLink.Explorer />,
-        },
-        queryParams.id
-          ? {
-              key: 'breadcrumb-block-details',
-              link: (
-                <BreadcrumbLink.BlockInfo
-                  to={{
-                    pathname: RoutePaths.BlockInfo,
-                    query: { id: queryParams.id },
-                  }}
-                />
-              ),
-            }
-          : null,
-        {
-          key: 'breadcrumb-transaction-details',
-          link: <BreadcrumbLink.TransactionInfo isCurrent={true} />,
-        },
-      ].filter(breadcrumb => breadcrumb !== null)
+      ]
+
+      if (queryParams.id) {
+        breadcrumbs.push(
+          {
+            key: 'breadcrumb-explorer',
+            link: <BreadcrumbLink.Explorer />,
+          },
+          {
+            key: 'breadcrumb-block-details',
+            link: (
+              <BreadcrumbLink.BlockInfo
+                to={{
+                  pathname: RoutePaths.BlockInfo,
+                  query: { id: queryParams.id },
+                }}
+              />
+            ),
+          }
+        )
+      }
+
+      breadcrumbs.push({
+        key: 'breadcrumb-transaction-details',
+        link: <BreadcrumbLink.TransactionInfo isCurrent={true} />,
+      })
+
+      return breadcrumbs
   }
 }
 

--- a/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/components/Breadcrumbs/Breadcrumbs.tsx
@@ -94,22 +94,24 @@ const resolvePath = (path: string, queryParams: ParsedUrlQuery | null) => {
           key: 'breadcrumb-explorer',
           link: <BreadcrumbLink.Explorer />,
         },
-        {
-          key: 'breadcrumb-block-details',
-          link: (
-            <BreadcrumbLink.BlockInfo
-              to={{
-                pathname: RoutePaths.BlockInfo,
-                query: { id: queryParams.id },
-              }}
-            />
-          ),
-        },
+        queryParams.id
+          ? {
+              key: 'breadcrumb-block-details',
+              link: (
+                <BreadcrumbLink.BlockInfo
+                  to={{
+                    pathname: RoutePaths.BlockInfo,
+                    query: { id: queryParams.id },
+                  }}
+                />
+              ),
+            }
+          : null,
         {
           key: 'breadcrumb-transaction-details',
           link: <BreadcrumbLink.TransactionInfo isCurrent={true} />,
         },
-      ]
+      ].filter(breadcrumb => breadcrumb !== null)
   }
 }
 

--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -33,13 +33,15 @@ import {
   LargeArrowRightUp,
   SizeIcon,
   CompassIcon,
+  BlockInfoHeightIcon,
 } from 'svgx'
 import { getIRFAmountWithCurrency } from 'utils/currency'
-import { NoteType, SpendType, TransactionType } from 'types'
+import { BlockHead, NoteType, SpendType, TransactionType } from 'types'
 import safeProp from 'utils/safeProp'
 import { formatBlockTimestamp } from 'utils/format'
 import { MintsBurnsList } from 'components/CustomAssets/MintsBurnsList/MintsBurnsList'
 import ColumnTable from 'components/ColumnTable'
+import useBlockHead from 'hooks/useBlockHead'
 
 type TransactionDescriptionType = 'inputs' | 'outputs'
 
@@ -191,6 +193,12 @@ const TRANSACTION_INFO_CARDS = [
     icon: <CompassIcon />,
   },
   {
+    key: 'expiration-card',
+    label: 'Expiration',
+    value: safeProp('expiration'),
+    icon: <BlockInfoHeightIcon />,
+  },
+  {
     key: 'timestamp-card',
     label: 'Timestamp',
     value: pipe(pathOr({}, ['blocks', 0]), formatBlockTimestamp),
@@ -222,10 +230,11 @@ const TRANSACTION_INFO_CARDS = [
 
 interface TransactionInfoProps {
   data: TransactionType
+  head: BlockHead
   loaded: boolean
 }
 
-const TransactionInfo: FC<TransactionInfoProps> = ({ data, loaded }) => {
+const TransactionInfo: FC<TransactionInfoProps> = ({ data, loaded, head }) => {
   const $subTextColor = useColorModeValue(
     NAMED_COLORS.GREY,
     NAMED_COLORS.PALE_GREY
@@ -240,12 +249,18 @@ const TransactionInfo: FC<TransactionInfoProps> = ({ data, loaded }) => {
     )
   }, [data?.notes?.length, data?.spends?.length])
 
-  const badge =
-    data?.blocks.length === 0
-      ? 'Pending'
-      : data?.blocks?.every(block => block.main === false)
-      ? 'Forked'
-      : null
+  const isPending = data?.blocks.length === 0
+  const isExpired =
+    isPending && 0 < data?.expiration && data?.expiration <= head?.sequence
+  const isForked = data?.blocks?.every(block => block.main === false)
+
+  const badge = isExpired
+    ? 'Expired'
+    : isPending
+    ? 'Pending'
+    : isForked
+    ? 'Forked'
+    : null
 
   return (
     <>
@@ -322,8 +337,9 @@ export default function TransactionInformationPage() {
 
   const { data, loaded, error } = useTransactionByHash(hash as string)
   const block = pathOr({}, ['blocks', 0])(data)
+  const head = useBlockHead()
 
-  if (error) {
+  if (error || head.error) {
     throw error
   }
 
@@ -336,7 +352,7 @@ export default function TransactionInformationPage() {
         <Box mt="2.5rem">
           <Breadcrumbs queryParams={{ id: block.sequence }} />
         </Box>
-        <TransactionInfo data={data} loaded={loaded} />
+        <TransactionInfo data={data} loaded={loaded} head={head.data} />
       </Box>
     </>
   )

--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -137,6 +137,10 @@ const TRANSACTION_INFO_CARDS = [
     key: 'block-hash-card',
     label: 'Block Hash',
     value: (transaction: TransactionType | null) => {
+      if (transaction?.blocks.length === 0) {
+        return null
+      }
+
       const index = transaction?.blocks.findIndex(block => block.main === true)
       const hash = pathOr('', [
         'blocks',
@@ -236,13 +240,18 @@ const TransactionInfo: FC<TransactionInfoProps> = ({ data, loaded }) => {
     )
   }, [data?.notes?.length, data?.spends?.length])
 
+  const badge =
+    data?.blocks.length === 0
+      ? 'Pending'
+      : data?.blocks?.every(block => block.main === false)
+      ? 'Forked'
+      : null
+
   return (
     <>
       <Flex mt="0.5rem" mb="2rem" align="center">
         <h3>Transaction Information</h3>
-        {data?.blocks?.every(block => block.main === false) && (
-          <InfoBadge ml={'1rem'} message={'Forked'} />
-        )}
+        {badge && <InfoBadge ml={'1rem'} message={badge} />}
       </Flex>
       <CardsView cards={TRANSACTION_INFO_CARDS} data={{ data, loaded }} />
       <Box mt="2rem" mb="0.5rem">

--- a/types/domain/TransactionType.ts
+++ b/types/domain/TransactionType.ts
@@ -20,6 +20,7 @@ export interface TransactionType {
   blocks?: BlockType[]
   burns: AssetDescriptionType[]
   mints: AssetDescriptionType[]
+  expiration?: number
 }
 
 export default TransactionType


### PR DESCRIPTION
the transaction page in the block explorer assumes that each transaction is on at least one block.

if we begin syncing pending transactions from the api-node to the api then the block explorer will display transactions that are not on any block.

- omits the 'Block Info' breadcrumb link if the query params do not include a block id
- displays a 'Pending' badge if the transaction is not on a block
- omits the 'Block Hash' card if the transaction is not on a block

before:
<img width="924" alt="image" src="https://github.com/iron-fish/block-explorer/assets/57735705/e9577123-6921-4f69-995b-b9e92609c9ea">

after:
![image](https://github.com/iron-fish/block-explorer/assets/57735705/f8aa57b6-08c8-44d3-923c-957f14922142)

Resolves IFL-1030
