### PR TITLE
Add download transaction button to tx page

### DIFF
--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -11,6 +11,7 @@ import {
   HStack,
   VStack,
   TableProps,
+  Tooltip,
 } from '@ironfish/ui-kit'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
@@ -42,6 +43,7 @@ import { formatBlockTimestamp } from 'utils/format'
 import { MintsBurnsList } from 'components/CustomAssets/MintsBurnsList/MintsBurnsList'
 import ColumnTable from 'components/ColumnTable'
 import useBlockHead from 'hooks/useBlockHead'
+import { getDownloadUrl } from 'utils/downloadUrl'
 
 type TransactionDescriptionType = 'inputs' | 'outputs'
 
@@ -228,6 +230,38 @@ const TRANSACTION_INFO_CARDS = [
   },
 ]
 
+interface TransactionDownloadProps {
+  data: TransactionType
+  loaded: boolean
+}
+
+const TransactionDownload: FC<TransactionDownloadProps> = ({
+  data,
+  loaded,
+}) => {
+  if (!loaded || !data) {
+    return null
+  }
+
+  const tooltip = data.serialized
+    ? null
+    : 'This transaction cannot be downloaded.'
+
+  const download = data.serialized
+    ? getDownloadUrl(data.serialized, 'text/plain')
+    : undefined
+
+  return (
+    <a download={data.hash + '.txt'} href={download}>
+      <Tooltip label={tooltip}>
+        <Button variant="secondary" size="medium" isDisabled={!data.serialized}>
+          Download Transaction
+        </Button>
+      </Tooltip>
+    </a>
+  )
+}
+
 interface TransactionInfoProps {
   data: TransactionType
   head: BlockHead
@@ -269,6 +303,9 @@ const TransactionInfo: FC<TransactionInfoProps> = ({ data, loaded, head }) => {
         {badge && <InfoBadge ml={'1rem'} message={badge} />}
       </Flex>
       <CardsView cards={TRANSACTION_INFO_CARDS} data={{ data, loaded }} />
+      <Box mt="2rem" mb="0.5rem">
+        <TransactionDownload data={data} loaded={loaded} />
+      </Box>
       <Box mt="2rem" mb="0.5rem">
         <h3>Inputs / Outputs</h3>
       </Box>

--- a/types/domain/TransactionType.ts
+++ b/types/domain/TransactionType.ts
@@ -21,6 +21,7 @@ export interface TransactionType {
   burns: AssetDescriptionType[]
   mints: AssetDescriptionType[]
   expiration?: number
+  serialized?: string
 }
 
 export default TransactionType

--- a/utils/downloadUrl.ts
+++ b/utils/downloadUrl.ts
@@ -1,0 +1,3 @@
+export const getDownloadUrl = (content: string, type: string): string => {
+  return URL.createObjectURL(new Blob([content], { type }))
+}


### PR DESCRIPTION
This adds a new button to download the serialized transaction if it's present.

# 1. Downloadable
<img width="344" alt="Screenshot 2024-01-11 at 4 36 29 PM" src="https://github.com/iron-fish/block-explorer/assets/458976/8f313c60-cfaf-490b-a440-26b9bd8718cf">

#  2. Not downloadable
<img width="277" alt="Screenshot 2024-01-11 at 4 36 15 PM" src="https://github.com/iron-fish/block-explorer/assets/458976/ac6d840e-0d8d-4969-8d16-98cbb69c5eab">

# 3. Downloaded
![Screenshot 2024-01-11 at 4 36 58 PM](https://github.com/iron-fish/block-explorer/assets/458976/cfd4b70c-fe79-4e01-bda5-2d2e8244e8a4)
