### PR TITLE
Transaction breadcrumbs should link to the block hash

### DIFF
--- a/pages/transaction/[hash].tsx
+++ b/pages/transaction/[hash].tsx
@@ -389,7 +389,7 @@ export default function TransactionInformationPage() {
       </Head>
       <Box mb="6rem" zIndex={1}>
         <Box mt="2.5rem">
-          <Breadcrumbs queryParams={{ id: block.sequence }} />
+          <Breadcrumbs queryParams={{ id: block.hash }} />
         </Box>
         <TransactionInfo data={data} loaded={loaded} head={head.data} />
       </Box>


### PR DESCRIPTION
This is because it's possible to click on the transaction from a linked forked, and then click on the bread crumb and go to a block that doesn't even contain that transaction.