### PR TITLE
Add difficulty formatter

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,7 @@ import {
 import NextLink from 'next/link'
 import { BlockHead } from 'types'
 import { formatTimeSinceLastBlock } from 'utils/format/formatTimeSinceLastBlock'
+import { formatDifficulty } from 'utils/format/units'
 import { renderIronWithCurrency } from 'utils/currency'
 
 const BLOCKS_LIMIT = 10
@@ -31,7 +32,7 @@ const LAST_BLOCK_INFO_CARDS = [
     key: 'difficulty-card',
     label: 'Difficulty',
     value: (block: BlockHead | null) =>
-      `${(Number(block?.difficulty) / 1e15).toFixed(2)}P`,
+      formatDifficulty(Number(block?.difficulty)),
     icon: <DifficultyIcon />,
   },
   {

--- a/utils/format/units.ts
+++ b/utils/format/units.ts
@@ -1,0 +1,45 @@
+import { floorTo } from 'utils/math'
+
+type SizeSuffix = {
+  B: string
+  K: string
+  M: string
+  G: string
+  T: string
+  P: string
+}
+
+const formatUnit = (
+  bytes: number,
+  base: number,
+  suffix: SizeSuffix
+): string => {
+  if (bytes < Math.pow(base, 1)) {
+    return `${bytes.toFixed(0)} ${suffix.B}`
+  }
+  if (bytes < Math.pow(base, 2)) {
+    return floorTo(bytes / Math.pow(base, 1), 2).toFixed(2) + ` ${suffix.K}`
+  }
+  if (bytes < Math.pow(base, 3)) {
+    return floorTo(bytes / Math.pow(base, 2), 2).toFixed(2) + ` ${suffix.M}`
+  }
+  if (bytes < Math.pow(base, 4)) {
+    return floorTo(bytes / Math.pow(base, 3), 2).toFixed(2) + ` ${suffix.G}`
+  }
+  if (bytes < Math.pow(base, 5)) {
+    return floorTo(bytes / Math.pow(base, 4), 2).toFixed(2) + ` ${suffix.T}`
+  }
+
+  return floorTo(bytes / Math.pow(base, 5), 2).toFixed(2) + ` ${suffix.P}`
+}
+
+export const formatDifficulty = (difficulty: number): string => {
+  return formatUnit(difficulty, 1000, {
+    B: '',
+    K: 'K',
+    M: 'M',
+    G: 'G',
+    T: 'T',
+    P: 'P',
+  })
+}

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -1,0 +1,6 @@
+export function floorTo(value: number, places: number): number {
+  const multiplier = Math.pow(10, places)
+  const adjusted = value * multiplier
+  const truncated = adjusted < 0 ? Math.ceil(adjusted) : Math.floor(adjusted)
+  return truncated / multiplier
+}


### PR DESCRIPTION
To dispaly difficulty on the main page in the correct unit.

## Before (Testnet)
<img width="320" alt="Screenshot 2024-03-06 at 4 33 40 PM" src="https://github.com/iron-fish/block-explorer/assets/458976/a7a16ee1-e9d1-46d1-bb0f-2bd158d41082">

## After (Testnet)
<img width="335" alt="Screenshot 2024-03-06 at 4 32 27 PM" src="https://github.com/iron-fish/block-explorer/assets/458976/09a600f3-6f18-4439-834d-6c8e305a8057">

## After (Mainnet)
<img width="327" alt="Screenshot 2024-03-06 at 4 34 49 PM" src="https://github.com/iron-fish/block-explorer/assets/458976/acefe587-f409-4c61-833e-3366adf3640f">
