### PR TITLE
adding previous block hash to block page on explorer

### DIFF
--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -1,11 +1,11 @@
-import { Box, Flex } from '@ironfish/ui-kit'
+import { Box, Flex, NAMED_COLORS } from '@ironfish/ui-kit'
 import size from 'byte-size'
 import {
   CardsView,
   CopyValueToClipboard,
   HashView,
   InfoBadge,
-  TimeStamp,
+  TimeStamp
 } from 'components'
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs'
 import { TransactionsTable } from 'components/TransactionsTable'
@@ -22,7 +22,7 @@ import {
   BlockInfoTimestampIcon,
   BlockInfoTxnIcon,
   DifficultyIcon,
-  PickIcon,
+  PickIcon
 } from 'svgx'
 import { BlockType } from 'types'
 import { formatTimeSinceLastBlock } from 'utils/format/formatTimeSinceLastBlock'
@@ -55,10 +55,18 @@ const BLOCK_CARDS = [
     label: 'Previous Block hash',
     value: block => {
       const previous_block_hash = safeProp('previous_block_hash')(block)
+      const sequence = safeProp('sequence')(block)
       return (
         <CopyValueToClipboard
           value={previous_block_hash}
-          label={<HashView hash={previous_block_hash} parts={2} />}
+          label={
+            <a
+              href={`/blocks/${sequence - 1}`}
+              style={{ color: NAMED_COLORS.LIGHT_BLUE }}
+            >
+              <HashView hash={previous_block_hash} parts={2} />
+            </a>
+          }
         />
       )
     },
@@ -138,9 +146,9 @@ const BlockInfo = ({ id }) => {
         data={
           block.loaded
             ? block.data?.transactions.map(transaction => ({
-                ...transaction,
-                blocks: [block.data],
-              }))
+              ...transaction,
+              blocks: [block.data],
+            }))
             : [null]
         }
       />

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -55,13 +55,12 @@ const BLOCK_CARDS = [
     label: 'Previous Block hash',
     value: block => {
       const previous_block_hash = safeProp('previous_block_hash')(block)
-      const sequence = safeProp('sequence')(block)
       return (
         <CopyValueToClipboard
           value={previous_block_hash}
           label={
             <a
-              href={`/blocks/${sequence - 1}`}
+              href={`/blocks/${previous_block_hash}`}
               style={{ color: NAMED_COLORS.LIGHT_BLUE }}
             >
               <HashView hash={previous_block_hash} parts={2} />

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -5,7 +5,7 @@ import {
   CopyValueToClipboard,
   HashView,
   InfoBadge,
-  TimeStamp
+  TimeStamp,
 } from 'components'
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs'
 import { TransactionsTable } from 'components/TransactionsTable'
@@ -22,7 +22,7 @@ import {
   BlockInfoTimestampIcon,
   BlockInfoTxnIcon,
   DifficultyIcon,
-  PickIcon
+  PickIcon,
 } from 'svgx'
 import { BlockType } from 'types'
 import { formatTimeSinceLastBlock } from 'utils/format/formatTimeSinceLastBlock'
@@ -146,9 +146,9 @@ const BlockInfo = ({ id }) => {
         data={
           block.loaded
             ? block.data?.transactions.map(transaction => ({
-              ...transaction,
-              blocks: [block.data],
-            }))
+                ...transaction,
+                blocks: [block.data],
+              }))
             : [null]
         }
       />

--- a/pages/blocks/[id].tsx
+++ b/pages/blocks/[id].tsx
@@ -51,6 +51,20 @@ const BLOCK_CARDS = [
     icon: <DifficultyIcon />,
   },
   {
+    key: 'prev-hash-card',
+    label: 'Previous Block hash',
+    value: block => {
+      const previous_block_hash = safeProp('previous_block_hash')(block)
+      return (
+        <CopyValueToClipboard
+          value={previous_block_hash}
+          label={<HashView hash={previous_block_hash} parts={2} />}
+        />
+      )
+    },
+    icon: <DifficultyIcon />,
+  },
+  {
     key: 'size-card',
     label: 'Size',
     value: pipe(


### PR DESCRIPTION
Adds the previous block hash to explorer: 

<img width="1114" alt="image" src="https://github.com/iron-fish/block-explorer/assets/13268167/5674f050-9a65-4b2b-b17a-48d8d7fbff58">
