### PR TITLE
removing copy to clipboard for transaction hash

### DIFF
--- a/components/TransactionsTable/TransactionsTable.tsx
+++ b/components/TransactionsTable/TransactionsTable.tsx
@@ -1,7 +1,7 @@
 import { Box, useBreakpointValue } from '@ironfish/ui-kit'
 import {
   ColumnProps,
-  CommonTableProps
+  CommonTableProps,
 } from '@ironfish/ui-kit/dist/components/Table/types'
 import { pathOr } from 'ramda'
 import { FC } from 'react'
@@ -10,7 +10,7 @@ import {
   ExplorerCommonTable,
   HashView,
   InfoBadge,
-  TableCellTimeStamp
+  TableCellTimeStamp,
 } from 'components'
 import TransactionType from 'types/domain/TransactionType'
 import { formatNumberWithLanguage } from 'utils/format'

--- a/components/TransactionsTable/TransactionsTable.tsx
+++ b/components/TransactionsTable/TransactionsTable.tsx
@@ -1,24 +1,23 @@
-import { FC } from 'react'
-import { NAMED_COLORS, useBreakpointValue, Box } from '@ironfish/ui-kit'
-import { pathOr } from 'ramda'
+import { Box, useBreakpointValue } from '@ironfish/ui-kit'
 import {
   ColumnProps,
-  CommonTableProps,
+  CommonTableProps
 } from '@ironfish/ui-kit/dist/components/Table/types'
+import { pathOr } from 'ramda'
+import { FC } from 'react'
 
-import { formatNumberWithLanguage } from 'utils/format'
-import TransactionType from 'types/domain/TransactionType'
-import { safeProp } from 'utils/safeProp'
 import {
-  CopyValueToClipboard,
-  InfoBadge,
-  HashView,
-  TableCellTimeStamp,
   ExplorerCommonTable,
+  HashView,
+  InfoBadge,
+  TableCellTimeStamp
 } from 'components'
+import TransactionType from 'types/domain/TransactionType'
+import { formatNumberWithLanguage } from 'utils/format'
+import { safeProp } from 'utils/safeProp'
 
-import { BlueHashIcon } from 'svgx'
 import { ACTIONS_COLUMN } from 'components/ExplorerCommonTable'
+import { BlueHashIcon } from 'svgx'
 
 const TAG_COLUMN: ColumnProps<TransactionType> = {
   key: 'transaction-tag',
@@ -42,11 +41,7 @@ const HASH_COLUMN: ColumnProps<TransactionType> = {
         <Box mr="1rem">
           <BlueHashIcon pb="0.1rem" h="1.875rem" w="1.625rem" />
         </Box>
-        <CopyValueToClipboard
-          labelProps={{ color: NAMED_COLORS.LIGHT_BLUE }}
-          value={hash}
-          label={<HashView hash={hash} />}
-        />
+        <HashView hash={hash} />
       </>
     )
   },

--- a/types/domain/BlockType.ts
+++ b/types/domain/BlockType.ts
@@ -17,8 +17,8 @@ export interface BlockType {
 }
 
 export interface BlockHead extends BlockType {
-  circulating_supply: number;
-  total_supply: number;
+  circulating_supply: number
+  total_supply: number
 }
 
 export function isBlock(x: unknown): x is BlockType {


### PR DESCRIPTION
Before: 

<img width="1027" alt="image" src="https://github.com/iron-fish/block-explorer/assets/13268167/7d28394d-7211-4902-b3f2-a73af55c538e">


You can't click on the copy transaction button. It is overridden by the link functionality for the row. 
I don't think we need the text for the hash to be blue, the row looks like a link itself. 

From my use, I don't attempt to copy the transaction hash on this page (you can't do that anyways). I go to the transaction page and view the details, maybe I copy the link there.

After: 
<img width="1146" alt="image" src="https://github.com/iron-fish/block-explorer/assets/13268167/52129cb7-4fc8-4215-8b6b-f417fbbec775">
